### PR TITLE
splat the hash for ruby 3

### DIFF
--- a/lib/paperclip-vips/paperclip/vips.rb
+++ b/lib/paperclip-vips/paperclip/vips.rb
@@ -27,11 +27,11 @@ module Paperclip
       destination = TempfileFactory.new.generate(filename)
 
       begin
-        thumbnail = ::Vips::Image.thumbnail(source.path, width, { height: crop ? height : nil, crop: crop }) if @target_geometry
+        thumbnail = ::Vips::Image.thumbnail(source.path, width, **{ height: crop ? height : nil, crop: crop }) if @target_geometry
         thumbnail = ::Vips::Image.new_from_file(source.path) if !defined?(thumbnail) || thumbnail.nil?
         thumbnail = process_convert_options(thumbnail)
         save_thumbnail(thumbnail, destination.path)
-        
+
       rescue => e
         if @whiny
           message = "There was an error processing the thumbnail for #{@basename}:\n" + e.message
@@ -68,7 +68,7 @@ module Paperclip
       def height
         @target_geometry&.height || @current_geometry.height
       end
-      
+
       def process_convert_options(image)
         if image
           commands = parsed_convert_commands(@convert_options)


### PR DESCRIPTION
After upgrading to Ruby 3, this error is observed:
```
     Paperclip::Error:
       There was an error processing the thumbnail for 84673dfdf4c987de324a0b59c890569c20250122-20110-6ckkpi:
       unable to call thumbnail: you supplied 3 arguments, but operation needs 2.
     # /Users/john.coote/.rvm/gems/ruby-3.2.2@rails7.0_ruby_275/gems/paperclip-vips-1.2.2/lib/paperclip-vips/paperclip/vips.rb:38:in `rescue in make'
     # /Users/john.coote/.rvm/gems/ruby-3.2.2@rails7.0_ruby_275/gems/paperclip-vips-1.2.2/lib/paperclip-vips/paperclip/vips.rb:29:in `make'
 ```

This PR splats the last hash into keyword arguments